### PR TITLE
Begrense flere kjernekomiteverv samtidig

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -94,6 +94,8 @@ Komiteens lederkandidat velges internt i komiteen før generalforsamlingen avhol
 
 Kun medlemmer av linjeforeningen kan inneha verv i en kjernekomité. Dersom studenten ikke lengre kvalifiserer til medlemskap i linjeforeningen kan vervet fortsette etter avtale med Hovedstyret.
 
+En person kan ikke inneha verv i flere av Onlines kjernekomiteer til samme tid uten avtale med Hovedstyret. Verv i Bankom og Backlog kan kombineres med en annen kjernekomite.
+
 ==== 4.2.1 Arrangementskomiteen
 
 Komiteens hovedoppgave er å koordinere og gjennomføre sosiale arrangement. Komiteens navn forkortes arrkom.


### PR DESCRIPTION
# Bakgrunn for saken

For å kunne tilby flere et verv i linjeforeninger vår og unngå interessekonflikter mellom roller i verv ønsker vi å vedtekstfeste at man skal unngå å ha flere kjernekomiteverv samtidig. Ved behov, mangel på medlemmer eller andre grunner kan hovedstyret fortsatt godkjenne verv i flere kjernekomiteer. Går utenom Bankom og Seniorkom/Backlog.

### Meldt inn av

Anders Robstad
