### PR TITLE
Legge Debug inn under “4.4 Andre grupper tilknyttet Online”

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -174,7 +174,7 @@ Output er linjeforeningens band, hvis formål er å bistå som underholdning på
 
 ==== 4.4.5 Debug
 
-Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2. Hovedtillitsvalgt for linjeforeningen er en del av Debug, og har ansvar for de tillitsvalgte i linjeforeningens komiteer. Hovedtillitsvalgt velges på generalforsamlingen.
+Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2.
 
 === 4.5 Interessegrupper
 

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -172,6 +172,10 @@ Realfagskjellerens hovedoppgave er å opprettholde et sosialt lavterskeltilbud f
 
 Output er linjeforeningens band, hvis formål er å bistå som underholdning på linjeforeningens arrangementer og andre arrangementer der det er aktuelt.
 
+==== 4.4.5 Debug
+
+Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2, og er linjeforeningens hovedtillitsvalgt.
+
 === 4.5 Interessegrupper
 
 Interessegrupper kan opprettes av Online-medlemmer som ønsker å dekke et behov som gagner informatikkstudenter. Disse grupperingene formulerer sine egne retningslinjer og godkjennes av seniorkomiteen.

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -174,7 +174,7 @@ Output er linjeforeningens band, hvis formål er å bistå som underholdning på
 
 ==== 4.4.5 Debug
 
-Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2, og er linjeforeningens hovedtillitsvalgt.
+Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2.
 
 === 4.5 Interessegrupper
 

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -174,7 +174,7 @@ Output er linjeforeningens band, hvis formål er å bistå som underholdning på
 
 ==== 4.4.5 Debug
 
-Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2.
+Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2. Hovedtillitsvalgt for linjeforeningen er en del av Debug, og har ansvar for de tillitsvalgte i linjeforeningens komiteer. Hovedtillitsvalgt velges på generalforsamlingen.
 
 === 4.5 Interessegrupper
 


### PR DESCRIPTION
# Bakgrunn for saken

Debug har etablert seg som en gruppering med medlemmer og leder, og har fått startet opp ordentlig det siste året. Grupperingen står foreløpig ikke i vedtektene, men er i praksis en uavhengig del av Online, med retningslinjer og gjensidig intensjonsavtale med Hovedstyret. Derfor ønsker Debug at dets eksistens skal reflekteres i vedtektene, på lik linje med andre uavhengige grupperinger som Output og Realfagskjelleren. Vi ønsker også at generalforsamlingen skal ha mulighet til å godkjenne leder, da denne personen har et spesielt viktig ansvar overfor linjeforeningens medlemmer.

### Meldt inn av

Debug
