### PR TITLE
Linjeforeningens hovedtillitsvalgt velges av generalforsamlingen

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -222,6 +222,10 @@ Ridderordenen består av flere grader hvor høyere grader betegner større engas
 
 Ridderordenen bestyrer selv sitt eget opptak og vurdering av kandidater. Utnevnelser foregår i formelle anledninger der en betydelig del av linjeforeningens medlemmer er samlet. Før Ridderordenen kan utnevne kandidater skal sittende leder av Hovedstyret underrettes om hvilke kandidater det gjelder. For å vurderes til utnevnelse må en kandidat på et tidspunkt ha oppfylt kravene til medlemskap, jf. §3. Engasjement som vektlegges når Ridderordenen vurderer kandidater inkluderer verv i linjeforeningen og andre organisasjoner som er direkte knyttet til linjeforeningen.
 
+==== 4.10 Hovedtillitsvalgt
+
+Hovedtillitsvalgt for linjeforeningen har ansvar for de tillitsvalgte i linjeforeningens komiteer, og velges på generalforsamlingen.
+
 == §5 Generalforsamlingen
 
 Generalforsamlingen er linjeforeningens øverste organ. Generalforsamlingen avholdes årlig i løpet av vårsemesteret.


### PR DESCRIPTION
**Faller dersom #18 faller**

# Bakgrunn for saken

Hovedtillitsvalgt i Online har før vært et ansvar hos et medlem i seniorkomiteen, men har de senere årene ikke lengre vært praksis. Vi ønsker å tydeliggjøre denne rollen, og sørge for mer struktur rundt tillitsvalgte i linjeforeningen. Dersom denne personen ikke er leder av Debug, foreslår vi at personen velges under generalforsamlingen. Det er viktig at medlemmene av linjeforeningen kan stå inne for personen, og at den ikke har direkte tilknytning til styret.

### Meldt inn av

Debug
