### PR TITLE
Endre frist for revidering av budsjett

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -322,7 +322,7 @@ Budsjettet skal være forsvarlig og det skal ikke, med mindre sterke grunner tal
 
 ==== 7.1.3 Revidering av budsjett
 
-Linjeforeningens budsjett for høstsemesteret kan revideres av Bank- og økonomikomiteen i løpet av våren. Revidert budsjett skal godkjennes av Hovedstyret innen 1. mai.
+Linjeforeningens budsjett for høstsemesteret kan revideres av Bank- og økonomikomiteen i løpet av våren og sommeren. Revidert budsjett skal godkjennes av Hovedstyret innen 1. september.
 
 ==== 7.1.4 Offentliggjøring av budsjett
 


### PR DESCRIPTION
# Bakgrunn for saken

For å sikre at Online sine midler blir brukt er det viktigt at budsjette blir revidert før vår og høst. Bankom vil revidere, regnskapsfører og se hvilke midler som ikke har blitt brukt. Hovedstyret godkjenner det reviderte budsjettforslaget bankom presenterer i lik linje med budsjette som presenteres i budsjettskveld.

### Meldt inn av

Milla Weium, @Thomhas 
