### PR TITLE
Økonomiansvarlig godkjenner budsjettoverskridelser

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -312,7 +312,7 @@ Makten til å godkjenne Onlines budsjett ligger hos Hovedstyret, men reguleres a
 
 Hovedstyret skal forvalte foreningens økonomi etter de vedtak som er fattet av generalforsamlingen og Hovedstyret under fastsettelse av budsjettet. Økonomiansvarlige sammen med sin komité har ansvaret for bruk av midler i henhold til sitt budsjett.
 
-Ikke-budsjetterte utgifter må godkjennes av Hovedstyret. Refundering av disse utgiftene vil kun forekomme dersom utgiften er godkjent.
+Ikke-budsjetterte utgifter må godkjennes av Økonomiansvarlig. Alle godkjente saker må presenteres for Hovedstyret. Refundering av disse utgiftene vil kun forekomme dersom utgiften er godkjent.
 
 ==== 7.1.2 Fastsettelse av budsjett
 


### PR DESCRIPTION
# Bakgrunn for saken

Å stemme over budsjettoverskridelser krever at man er oppdatert på linjeforeningens økonomi. Den personen med mest innsikt er linjeforeningens økonomiansvarlig. Dermed vil godkjenning av budsjettoverskridelser gjøres av Økonomiansvarlig for å tilrettelegge at prosessen blir mindre rigid.

### Meldt inn av

Milla Weium, @Thomhas 
