### PR TITLE
To generalforsamlinger i året

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -224,9 +224,9 @@ Ridderordenen bestyrer selv sitt eget opptak og vurdering av kandidater. Utnevne
 
 == §5 Generalforsamlingen
 
-Generalforsamlingen er linjeforeningens øverste organ. Generalforsamlingen avholdes årlig i løpet av vårsemesteret.
+Generalforsamlingen er linjeforeningens øverste organ. Det avholdes to generalforsamlinger årlig, én i løpet av vårsemesteret, og én i løpet av høstsemesteret.
 
-Den ordinære generalforsamlingen skal behandle årsmelding, innsendte saker, vedtektsendringer, valg og regnskap for foregående år, valg av nytt hovedstyre og valg av tre medlemmer til en ny valgkomité.
+Begge forsamlingene skal behandle årsmelding, innsendte saker og vedtektsendringer. Vårforsamlingen skal i tillegg behandle valg av nytt fondsstyre, regnskap for foregående år, valg av tre medlemmer til en ny valgkomité og valg av hovedstyret.
 
 === 5.1 Frister
 


### PR DESCRIPTION
# Bakgrunn for saken

Årets generalforsamling er forventet å vare til midnatt, gitt at alt går ekstremt radig av seg. Det er upraktisk at vi alltid må forholde oss til generalforsamlinger som varer så lenge at man ikke orker de siste sakene. Dersom man har flere generalforsamlinger i året vil forsamlingen bli særdeles mye mindre. Det bidrar til en mer handlingsdyktig generalforsamling. I tillegg vil det være anledning for å ta opp saker til generalforsamling dobbelt så ofte. TIHLDE har brukt denne løsningen lenge, og Abakus endret til det samme i høst.

### Meldt inn av

Sindre Langaard