### PR TITLE
Valg av styre ved begge genfors

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -86,6 +86,18 @@ Dersom leder, nestleder og/eller økonomiansvarlig av linjeforeningen blir frav�
 
 Kandidater til Hovedstyret må ha innehatt et verv i en av kjernekomiteene eller nodekomiteene i linjeforeningen i minst ett (1) semester. Om en kandidat ikke har innehatt et verv i en kjernekomité, må kandidaten foreslås av valgkomiteen.
 
+==== 4.1.4 Valg av Hovedstyre
+
+Verv i Hovedstyret varer normalt i to semestere og utlyses ved generalforsamlinger.
+
+Ved vår-generalforsamlingen utlyses:
+* Leder
+* Nestleder
+* Økonomiansvarlig
+
+Ved høst-generalforsamlingen utlyses:
+* Øvrige styrerepresentanter
+
 === 4.2 Kjernekomiteer
 
 Alle kjernekomiteer består av minimum en leder, og en økonomiansvarlig. Kjernekomiteer med stemmerett i Hovedstyret skal i tillegg bestå av et styremedlem.
@@ -226,7 +238,7 @@ Ridderordenen bestyrer selv sitt eget opptak og vurdering av kandidater. Utnevne
 
 Generalforsamlingen er linjeforeningens øverste organ. Det avholdes to generalforsamlinger årlig, én i løpet av vårsemesteret, og én i løpet av høstsemesteret.
 
-Begge forsamlingene skal behandle årsmelding, innsendte saker og vedtektsendringer. Vårforsamlingen skal i tillegg behandle valg av nytt fondsstyre, regnskap for foregående år, valg av tre medlemmer til en ny valgkomité og valg av hovedstyret.
+Begge forsamlingene skal behandle årsmelding, innsendte saker, vedtektsendringer og valg av hovedstyret. Vårforsamlingen skal i tillegg behandle valg av nytt fondsstyre, regnskap for foregående år, og valg av tre medlemmer til en ny valgkomité.
 
 === 5.1 Frister
 

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -98,6 +98,8 @@ Ved vår-generalforsamlingen utlyses:
 Ved høst-generalforsamlingen utlyses:
 * Øvrige styrerepresentanter
 
+Kandidater som ønsker å stille som leder, nestleder og økonomiansvarlig kan ikke sitte som øvrig styrerepresentant i det nåværende styret, og vice versa.
+
 === 4.2 Kjernekomiteer
 
 Alle kjernekomiteer består av minimum en leder, og en økonomiansvarlig. Kjernekomiteer med stemmerett i Hovedstyret skal i tillegg bestå av et styremedlem.

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -98,7 +98,7 @@ Ved vår-generalforsamlingen utlyses:
 Ved høst-generalforsamlingen utlyses:
 * Øvrige styrerepresentanter
 
-Kandidater som ønsker å stille som leder, nestleder og økonomiansvarlig kan ikke sitte som øvrig styrerepresentant i det nåværende styret, og vice versa.
+Sittende styremedlemmer kan kun stille som kandidat dersom de fratrer vervet sitt samme generalforsamling de stiller.
 
 === 4.2 Kjernekomiteer
 

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -224,9 +224,9 @@ Ridderordenen bestyrer selv sitt eget opptak og vurdering av kandidater. Utnevne
 
 == §5 Generalforsamlingen
 
-Generalforsamlingen er linjeforeningens øverste organ. Generalforsamlingen avholdes årlig i løpet av vårsemesteret.
+Generalforsamlingen er linjeforeningens øverste organ. Det avholdes to generalforsamlinger årlig, én i løpet av vårsemesteret, og én i løpet av høstsemesteret.
 
-Den ordinære generalforsamlingen skal behandle årsmelding, innsendte saker, vedtektsendringer, valg og regnskap for foregående år, valg av nytt hovedstyre og valg av tre medlemmer til en ny valgkomité.
+Begge forsamlingene skal behandle årsmelding, innsendte saker og vedtektsendringer. Vårforsamlingen skal i tillegg behandle valg av nytt fondsstyre, regnskap for foregående år, valg av tre medlemmer til en ny valgkomité og valg av hovedstyret.
 
 === 5.1 Frister
 


### PR DESCRIPTION
**Faller dersom #23 faller**

# Bakgrunn for saken

Per nå tar det ganske lang tid å bli handlingsdyktige som et helt ferskt styre, og det går mye tid til å lære seg the basics. Ved å sikre at halve styret sitter på 6 måneder erfaring når resten kommer inn, vil dette forbedres betraktelig. Det vil også gjøre erfaringsoverføringen mer garantert, da styret ikke er avhengig av at tidligere styremedlemmer er i stor grad tilgjengelig for spørsmål og svar. Det vil være lettere å holde en rød tråd i styrets arbeid, som gjør at prosjekter som varer over lengre tid er enklere å gjennomføre som styre.

### Meldt inn av

@anderssonw 
