### PR TITLE
Fjerning av parafering i vedtektene

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 Ved oppdatering av vedtektene skal det opprettes en innlemmingsforespørsel for hver enkel vedtektsendring. Dette er til for å kunne diskutere sakene utenfor diskusjonskvelder, og for god sporing av endringer gjennom tidene. Innlemmingsforespørselen skal bruke `Vedtektsendring` templaten som ligger i repoet. Innlemmingsforespørsler skal kun godkjennes etter de er fremmet på generalforsamling, godkjent av forsamlingen, og så godkjent av paraferer.
 
-## Signering av vedtekter
-
-Paraferer godkjenner endringer etter generalforsamling. Dette gjennomføres ved å kommentere en godkjennelse på alle relevante innlemmingsforespørsler.
-
-Etter godkjente endringer skal paraferene signere forsiden til vedtektene. Malen `forside_mal.pdf` signeres av paraferer og lastes opp på formatet `forside_semester_signert.pdf`, eksempelvis `forside_h2022_signert.pdf`. 
-
-Kun én signert forside skal ligge i repoet om gangen.
-
 ## Opplasting av vedtekter
 
 **Dette er for eksempel relevant for å sende oppdaterte vedtekter til Brønnøysundsregisteret**
@@ -24,5 +16,3 @@ Med `ruby >=2.5` må man laste ned noen gems i tillegg. Dersom ruby er lagt til 
 `gem install asciidoctor-pdf --pre`
 
 PDF kan så genereres ved å kjøre `asciidoctor-pdf vedtekter.adoc`.
-
-Slå sammen `forside_semester_signert.pdf` med den genererte `vedtekter.pdf`, så har man signerte vedtekter for avsending.

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -233,7 +233,7 @@ Den ordinære generalforsamlingen skal behandle årsmelding, innsendte saker, ve
 * Innkalling skal sendes ut til medlemmene senest _fire (4) uker_ før generalforsamlingen skal avholdes.
 * Saksforslag og forslag til vedtektsendringer sendes Hovedstyret senest _to (2) uker_ før generalforsamlingen skal avholdes.
 * Fullstendig saksliste med forslag til vedtektsendringer skal tilgjengeliggjøres senest _en (1) uke_ før møtedato. Denne skal også inneholde årsmelding, revidert regnskap, vedtatt budsjett for året og eventuelle andre relevante sakspapirer.
-* Referat fra generalforsamlingen skal underskrives av paraferer og sendes til medlemmene eller gjøres tilgjengelig for medlemmene senest _14 dager_ etter generalforsamlingen.
+* Referat fra generalforsamlingen skal korrekturleses og godkjennes av Hovedstyret, og sendes til medlemmene eller gjøres tilgjengelig for medlemmene senest _14 dager_ etter generalforsamlingen.
 
 === 5.2 Ekstraordinær generalforsamling
 
@@ -248,7 +248,6 @@ Ved konstituering av generalforsamlingen skal disse rollene fylles:
 * Ordstyrer
 * To referenter som skriver referat under generalforsamling og samarbeider om renskriving
 * Minst to til tellekorps som teller opp stemmer ved avstemming
-* To paraferer som godkjenner referat fra generalforsamling og de endrede vedtektene i etterkant av generalforsamlingen
 
 === 5.4 Beslutningsdyktighet og avstemming
 


### PR DESCRIPTION
# Bakgrunn for saken

Nå som Online bruker AsciiDoc for vedtekter, har vi lagt inn et system for bruk av GitHub og innlemmingsforespørsler ved eventuelle endring av vedtektene. Som informatikkstudenter har vi en gyllen mulighet til å bruke et så godt verktøy som git for kvalitetssikring og versjonskontrollering av vedtektene. Da mener jeg at hensikten bak konstituering av paraferere er unødvendig. Det kommer veldig tydelig fram i commit-historien hvilke endringer som er gjort, og alt av vedtekter ligger open source, som bør være kvalitetssikring nok.

### Meldt inn av

@anderssonw 
