### PR TITLE
Valg av styre ved begge genfors, V2

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -86,6 +86,20 @@ Dersom leder, nestleder og/eller økonomiansvarlig av linjeforeningen blir frav�
 
 Kandidater til Hovedstyret må ha innehatt et verv i en av kjernekomiteene eller nodekomiteene i linjeforeningen i minst ett (1) semester. Om en kandidat ikke har innehatt et verv i en kjernekomité, må kandidaten foreslås av valgkomiteen.
 
+==== 4.1.4 Valg av Hovedstyre
+
+Verv i Hovedstyret varer normalt i to semestere og utlyses ved generalforsamlinger.
+
+Ved vår-generalforsamlingen utlyses:
+* Leder
+* Nestleder
+* Økonomiansvarlig
+
+Ved høst-generalforsamlingen utlyses:
+* Øvrige styrerepresentanter
+
+Kandidater som ønsker å stille som leder, nestleder og økonomiansvarlig har anledning til å stille som øvrig styrerepresentant i det nåværende styret, og vice versa. Dersom kandidaten vinner skal det avholdes ekstraordinært valg for den avtroppende styreposisjonen.
+
 === 4.2 Kjernekomiteer
 
 Alle kjernekomiteer består av minimum en leder, og en økonomiansvarlig. Kjernekomiteer med stemmerett i Hovedstyret skal i tillegg bestå av et styremedlem.

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -98,7 +98,8 @@ Ved vår-generalforsamlingen utlyses:
 Ved høst-generalforsamlingen utlyses:
 * Øvrige styrerepresentanter
 
-Kandidater som ønsker å stille som leder, nestleder og økonomiansvarlig har anledning til å stille som øvrig styrerepresentant i det nåværende styret, og vice versa. Dersom kandidaten vinner skal det avholdes ekstraordinært valg for den avtroppende styreposisjonen.
+Sittende styremedlemmer kan stille som kandidat selv om de ikke fratrer vervet sitt samme generalforsamling de stiller. Dersom kandidaten vinner skal det avholdes ekstraordinært valg for den avtroppende styreposisjonen.
+
 
 === 4.2 Kjernekomiteer
 

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -100,7 +100,6 @@ Ved høst-generalforsamlingen utlyses:
 
 Sittende styremedlemmer kan stille som kandidat selv om de ikke fratrer vervet sitt samme generalforsamling de stiller. Dersom kandidaten vinner skal det avholdes ekstraordinært valg for den avtroppende styreposisjonen.
 
-
 === 4.2 Kjernekomiteer
 
 Alle kjernekomiteer består av minimum en leder, og en økonomiansvarlig. Kjernekomiteer med stemmerett i Hovedstyret skal i tillegg bestå av et styremedlem.


### PR DESCRIPTION
**Faller dersom #23 faller**
**Faller dersom #24 går gjennom**

# Bakgrunn for saken

Per nå tar det ganske lang tid å bli handlingsdyktige som et helt ferskt styre, og det går mye tid til å lære seg the basics. Ved å sikre at halve styret sitter på 6 måneder erfaring når resten kommer inn, vil dette forbedres betraktelig. Det vil også gjøre erfaringsoverføringen mer garantert, da styret ikke er avhengig av at tidligere styremedlemmer er i stor grad tilgjengelig for spørsmål og svar. Det vil være lettere å holde en rød tråd i styrets arbeid, som gjør at prosjekter som varer over lengre tid er enklere å gjennomføre som styre.

Denne versjonen tillater kandidater å stille til hovedstyreverv dersom de allerede sitter i ett av vervene. Da skal det avholdes et ekstraordinært valg av den avtroppende rollen.

### Meldt inn av

@anderssonw 
