### PR TITLE
Linjeforeningens hovedtillitsvalgt velges av generalforsamlingen og blir en del av Debug

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -174,7 +174,7 @@ Output er linjeforeningens band, hvis formål er å bistå som underholdning på
 
 ==== 4.4.5 Debug
 
-Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2. Hovedtillitsvalgt for linjeforeningen er en del av Debug, og har ansvar for de tillitsvalgte i linjeforeningens komiteer. Hovedtillitsvalgt velges på generalforsamlingen.
+Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2.
 
 === 4.5 Interessegrupper
 

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -172,6 +172,10 @@ Realfagskjellerens hovedoppgave er å opprettholde et sosialt lavterskeltilbud f
 
 Output er linjeforeningens band, hvis formål er å bistå som underholdning på linjeforeningens arrangementer og andre arrangementer der det er aktuelt.
 
+==== 4.4.5 Debug
+
+Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2, og er linjeforeningens hovedtillitsvalgt.
+
 === 4.5 Interessegrupper
 
 Interessegrupper kan opprettes av Online-medlemmer som ønsker å dekke et behov som gagner informatikkstudenter. Disse grupperingene formulerer sine egne retningslinjer og godkjennes av seniorkomiteen.

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -174,7 +174,7 @@ Output er linjeforeningens band, hvis formål er å bistå som underholdning på
 
 ==== 4.4.5 Debug
 
-Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2, og er linjeforeningens hovedtillitsvalgt.
+Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2.
 
 === 4.5 Interessegrupper
 

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -174,7 +174,7 @@ Output er linjeforeningens band, hvis formål er å bistå som underholdning på
 
 ==== 4.4.5 Debug
 
-Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2.
+Gruppens hovedoppgave er å fungere som linjeforeningens uavhengige varslingsorgan. Gruppen står fritt fra linjeforeningen, men er underlagt de retningslinjene og avtaler som er inngått med linjeforeningen. Leder velges jamfør ledervalg i 4.2. Hovedtillitsvalgt for linjeforeningen er en del av Debug, og har ansvar for de tillitsvalgte i linjeforeningens komiteer. Hovedtillitsvalgt velges på generalforsamlingen.
 
 === 4.5 Interessegrupper
 


### PR DESCRIPTION
**Faller dersom #18 faller**

# Bakgrunn for saken

Hovedtillitsvalgt i Online har før vært et ansvar hos et medlem i seniorkomiteen, men har de senere årene ikke lengre vært praksis. Vi ønsker å tydeliggjøre denne rollen, og sørge for mer struktur rundt tillitsvalgte i linjeforeningen. Dersom denne personen ikke er leder av Debug, foreslår vi at personen velges under generalforsamlingen. Det er viktig at medlemmene av linjeforeningen kan stå inne for personen, og at den ikke har direkte tilknytning til styret.

### Meldt inn av

Debug