### PR TITLE
Vedtektsforslag 02: endre frist for høstrevidering til 15.

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -347,7 +347,7 @@ Budsjettet skal være forsvarlig og det skal ikke, med mindre sterke grunner tal
 
 ==== 7.1.3 Revidering av budsjett
 
-Linjeforeningens budsjett for høstsemesteret kan revideres av Bank- og økonomikomiteen i løpet av våren og sommeren. Revidert budsjett skal godkjennes av Hovedstyret innen 1. september.
+Linjeforeningens budsjett for høstsemesteret kan revideres av Bank- og økonomikomiteen i løpet av våren og sommeren. Revidert budsjett skal godkjennes av Hovedstyret innen 15. september.
 
 ==== 7.1.4 Offentliggjøring av budsjett
 


### PR DESCRIPTION
# Bakgrunn for saken

- Per nå har bankom 2 uker på revidering av siste måned i halvåret, regnskapsføre og lage nytt budsjett.
- Disse to ukene faller midt i fadderuka.
- Må også godkjennes av HS, som kan ta litt tid hvis de har innvendinger eller endringsforslag til det nye budsjettet.
- Bankom ønsker derfor å utsette fristen med 14 dager, slik at vi har bedre tid til å lage et så bra og rettferdig budsjett som overhodet mulig. 


### Meldt inn av

Henrik Horten Hegli
