### PR TITLE
Vedtektsforslag 07: Komiteledere velges før vårens genfors

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -106,7 +106,7 @@ Sittende styremedlemmer kan stille som kandidat selv om de ikke fratrer vervet s
 
 Alle kjernekomiteer består av minimum en leder, og en økonomiansvarlig. Kjernekomiteer med stemmerett i Hovedstyret skal i tillegg bestå av et styremedlem.
 
-Komiteens lederkandidat velges internt i komiteen før generalforsamlingen avholdes, og godkjennes av generalforsamlingen ved alminnelig flertall. Dersom komitélederkandidaten har blitt stemt inn i Hovedstyret skal det avholdes valg av komitéleder etter §3. Hvis kandidaten ikke har blitt stemt inn i Hovedstyret, og generalforsamlingen ikke godkjenner kandidaten til ledervervet, skal det avholdes valg av komitéleder etter §3.
+Komiteens lederkandidat velges internt i komiteen før vårens generalforsamling avholdes, og godkjennes av generalforsamlingen ved alminnelig flertall. Dersom komitélederkandidaten har blitt stemt inn i Hovedstyret skal det avholdes valg av komitéleder etter §3. Hvis kandidaten ikke har blitt stemt inn i Hovedstyret, og generalforsamlingen ikke godkjenner kandidaten til ledervervet, skal det avholdes valg av komitéleder etter §3.
 
 Kun medlemmer av linjeforeningen kan inneha verv i en kjernekomité. Dersom studenten ikke lengre kvalifiserer til medlemskap i linjeforeningen kan vervet fortsette etter avtale med Hovedstyret.
 


### PR DESCRIPTION
# Bakgrunn for saken

- Det står ikke spesifisert før hvilken genfors ledere av kjernekjomiteene skal velges.
- Dermed ønsker vi å legge inn at lederne velges før vårens generalforsamling
    - Dette var hensikten med vedtektsendringer som ble fremmet i vår, så det er egentlig bare en formell opprydning etter dette. 


### Meldt inn av

Anders Robstad
