### PR TITLE
Vedtektsforslag 05: FeminIT som egen komite

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -110,7 +110,7 @@ Komiteens lederkandidat velges internt i komiteen før generalforsamlingen avhol
 
 Kun medlemmer av linjeforeningen kan inneha verv i en kjernekomité. Dersom studenten ikke lengre kvalifiserer til medlemskap i linjeforeningen kan vervet fortsette etter avtale med Hovedstyret.
 
-En person kan ikke inneha verv i flere av Onlines kjernekomiteer til samme tid uten avtale med Hovedstyret. Verv i Bankom og Backlog kan kombineres med en annen kjernekomite.
+En person kan ikke inneha verv i flere av Onlines kjernekomiteer til samme tid uten avtale med Hovedstyret. Verv i Bankom, Backlog og FeminIT kan kombineres med en annen kjernekomite.
 
 ==== 4.2.1 Arrangementskomiteen
 
@@ -151,6 +151,10 @@ Komiteens oppgave er å organisere idrettsgrupper og idrettsarrangementer for li
 ==== 4.2.10 Applikasjonskomiteen 
 
 Komiteens hovedoppgave er å utvikle og drifte egne it-systemer. Komiteens navn forkortes appkom.
+
+==== 4.2.11 Females in IT
+
+Komiteens hovedoppgave er å øke trivselen blant jenter på informatikk for å på sikt øke kvinneandelen. Komiteen legges ned etter at kvinneandelen av uteksaminerte studenter på informatikk har nådd 40% på bachelornivå og 30% på masternivå over tre år. Komiteens navn forkortes FeminIT.
 
 === 4.3 Nodekomiteer
 


### PR DESCRIPTION
# Bakgrunn for saken

På informatikk bachelor er det ca. 25% jenter. 
Høyt frafall av jenter.
Vår målsetning er å senke frafallet, ved å gi mulighet for å bli kjent med jenter på tvers av trinn, for å øke trivsel og beholde motivasjonen til å fullføre studiet. 
Vi ønsker at FeminIT skal bli en komité for å bevare vårt mål og styrke grupperingens posisjon i Online, også i fremtiden.

### Meldt inn av

Ida Matre og Hanne Sofie Haugland
