### PR TITLE
Vedtektsforslag 6: Endret slik at nodekomite-medlemmer kan stille til hs

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -84,7 +84,7 @@ Dersom leder, nestleder og/eller økonomiansvarlig av linjeforeningen blir frav�
 
 ==== 4.1.3 Krav til kandidater
 
-Kandidater til Hovedstyret må ha innehatt et verv i en av kjernekomiteene eller nodekomiteene i linjeforeningen i minst ett (1) semester. Om en kandidat ikke har innehatt et verv i en kjernekomité, må kandidaten foreslås av valgkomiteen.
+Kandidater til Hovedstyret må ha innehatt et verv i en av kjernekomiteene eller nodekomiteene i linjeforeningen i minst ett (1) semester. Om en kandidat til styrerepresentant ikke har innehatt et verv i en kjernekomité, må kandidaten foreslås av valgkomiteen.
 
 ==== 4.1.4 Valg av Hovedstyre
 


### PR DESCRIPTION
# Bakgrunn for saken

- Vedtektenes betydning er tvetydig slik den står nå.
- Et medlem av en/flere nodekomiteer kan gjøre en vel så god jobb som en i kjernekomite.
- Opp til generalforsamlingen å avgjøre hvem kandidater som er best egnet, ikke hvorvidt de kan stille pga. en gammel vedtekt.


### Meldt inn av

Robin Lund Sadun og Henrik Horten Hegli
