### PR TITLE
Vedtektsforslag 09 v1   innlemme debug i behandlingen av mistillitsforslag

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -231,15 +231,16 @@ a. Ethvert medlem av linjeforeningen kan fremme mistillitsforslag ovenfor enhver
     . Ved mistillitsforslag mot et hovedstyremedlem blir den anklagede suspendert inntil Hovedstyret har kommet med en avgjørelse.
     . Dersom det stilles mistillitsforslag til flere styremedlemmer av gangen, skal disse behandles ved ekstraordinær generalforsamling.
 
-b. Mistillitsforslaget skal leveres skriftlig til Hovedstyret, som skal behandle saken.
+b. Ved et mistillitsforslag skal man henvende seg skriftlig til Debug.
 
 ==== § 4.7.2 Saksbehandling
 
-a. Mistillitsforslaget leses opp i Hovedstyret av Leder av Online, deretter skal den anklagede få en mulighet til å forsvare seg.
+a. Mistillitsforslaget presenteres for Hovedstyret av Debug.
 b. Saken kan ikke behandles før minimum en -1- uke etter at Hovedstyret mottok mistillitsforslaget.
-c. Den anklagede har rett til innsyn i saksdokumentene i det øyeblikk Hovedstyret mottar mistillitsforslaget.
-d. Den anklagede har rett til å ha en tillitsvalgt til stede under sitt forsvar.
-e. Videre skal Hovedstyret komme frem til sin avgjørelse uten den anklagede tilstede.
+c. Den anklagde skal få mulighet til å forsvare seg, dersom vedkommende ønsker det.
+d. Den anklagede har rett til innsyn i saksdokumentene i det øyeblikk Hovedstyret mottar mistillitsforslaget.
+e. Den anklagede har rett til å ha en tillitsvalgt til stede under sitt forsvar.
+f. Videre skal Hovedstyret komme frem til sin avgjørelse uten den anklagede tilstede.
 
 
 === 4.8 Æresmedlemmer

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -224,7 +224,23 @@ Leder av en komité har rett til å si opp et medlem av sin egen komité. Oppsig
 
 === 4.7 Mistillit
 
-Ethvert medlem av linjeforeningen kan fremme mistillitsforslag ovenfor enhver innehaver av et verv i linjeforeningen. Mistillitsforslaget skal leveres skriftlig til Hovedstyret, som skal behandle saken. Saken kan ikke behandles før minimum en -1- uke etter at Hovedstyret mottok mistillitsforslaget. Den anklagde har rett til innsyn i saksdokumentene i det øyeblikk Hovedstyret mottar mistillitsforslaget. Ved mistillitsforslag mot et hovedstyremedlem blir den anklagede suspendert inntil Hovedstyret har kommet med en avgjørelse. Mistillitsforslaget leses opp i Hovedstyret av Leder av Online, deretter skal den anklagede få en mulighet til å forsvare seg. Den anklagde har rett til å ha en tillitsvalgt tilstede under sitt forsvar. Videre skal Hovedstyret komme frem til sin avgjørelse uten den anklagede tilstede. Dersom det stilles mistillitsforslag til flere styremedlemmer av gangen, skal disse behandles ved ekstraordinær generalforsamling.
+==== 4.7.1 Fremme mistillit
+
+a. Ethvert medlem av linjeforeningen kan fremme mistillitsforslag ovenfor enhver innehaver av et verv i linjeforeningen.
+
+    . Ved mistillitsforslag mot et hovedstyremedlem blir den anklagede suspendert inntil Hovedstyret har kommet med en avgjørelse.
+    . Dersom det stilles mistillitsforslag til flere styremedlemmer av gangen, skal disse behandles ved ekstraordinær generalforsamling.
+
+b. Mistillitsforslaget skal leveres skriftlig til Hovedstyret, som skal behandle saken.
+
+==== § 4.7.2 Saksbehandling
+
+a. Mistillitsforslaget leses opp i Hovedstyret av Leder av Online, deretter skal den anklagede få en mulighet til å forsvare seg.
+b. Saken kan ikke behandles før minimum en -1- uke etter at Hovedstyret mottok mistillitsforslaget.
+c. Den anklagede har rett til innsyn i saksdokumentene i det øyeblikk Hovedstyret mottar mistillitsforslaget.
+d. Den anklagede har rett til å ha en tillitsvalgt til stede under sitt forsvar.
+e. Videre skal Hovedstyret komme frem til sin avgjørelse uten den anklagede tilstede.
+
 
 === 4.8 Æresmedlemmer
 


### PR DESCRIPTION
# Bakgrunn for saken

- Online vedtok på generalforsamlingen V22 at debug offisielt skulle ha tilknytning til Online
- Hensikten til debug er å “gi linjeforeningens medlemmer et verktøy for å håndtere saker som oppleves krevende for medlemmer av linjeforeningen”
- Det er de som har mest kompetanse på dette området
- Vil gjøre prosessen bedre for alle involverte parter.


### Meldt inn av

Debug
