### PR TITLE
Vedtekstforslag 05: Debugmedlemmer kan ikke være med i HS

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -88,7 +88,7 @@ Dersom leder, nestleder og/eller økonomiansvarlig av linjeforeningen blir frav�
 
 ==== 4.1.3 Krav til kandidater
 
-Kandidater til Hovedstyret må ha innehatt et verv i en av komiteene i linjeforeningen i minst ett (1) semester. Om en kandidat til styrerepresentant ikke har innehatt et verv i en komité, må kandidaten foreslås av valgkomiteen.
+Kandidater til Hovedstyret må ha innehatt et verv i en av komiteene i linjeforeningen i minst ett (1) semester. Om en kandidat til styrerepresentant ikke har innehatt et verv i en komité, må kandidaten foreslås av valgkomiteen. Dersom kandidaten er med i Debug, må de permitteres fra dette vervet.
 
 ==== 4.1.4 Valg av Hovedstyre
 


### PR DESCRIPTION
# Bakgrunn for saken

Både HS og Debug har tillitsroller, uten at disse rollene nødvendigvis overlapper i f.eks personalsaker. Det er og visse ting som kommer til debug som ikke trenger å dukke opp hos noen i Hovedstyret, og motsatt. Dette har ikke vært en case tidligere, da Debug er en relativt ny ting og de som har overlappet frivillig har permittert seg derfra. Vi ønsker at dette ikke skal være opp til personen, da interessekonflikten uansett vil være der.

### Meldt inn av

Carolina Gunnesdal og Robin Lund Sadun
