### PR TITLE
Vedtektsforslag 01: Godkjenning av backlogleder

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -146,7 +146,7 @@ Komiteens hovedoppgave er å sørge for økt trivsel blant informatikere i hverd
 
 ==== 4.2.8 Backlog
 
-Komiteens hovedoppgave vil være å bistå med kunnskap, erfaring og assistanse i linjeforeningens daglige drift. Komiteens medlemmer skal primært bestå av medlemmer som har hatt et aktivt verv i linjeforeningen i fire (4) semester. Leder av backlog godkjennes av Hovedstyret.
+Komiteens hovedoppgave vil være å bistå med kunnskap, erfaring og assistanse i linjeforeningens daglige drift. Komiteens medlemmer skal primært bestå av medlemmer som har hatt et aktivt verv i linjeforeningen i fire (4) semester.
 
 ==== 4.2.9 Online idrettslag
 


### PR DESCRIPTION
# Bakgrunn for saken

I vedtektene under 4.2 Komiteer står det at alle komiteers lederkandidat, med unntak av nodekomiteer, skal godkjennes på generalforsamlingen. I backlogs vedtekter (4.2.8) står det at leder av backlog godkjennes av Hovedstyret. Ettersom backlog stadig blir mer etablert som en komite på lik linje som de andre komiteene ser vi det ikke nødvendig at backlog sin leder skal godkjennes av Hovedstyret, mens andre komiteledere godkjennes på generalforsamlingen. Vi ønsker dermed først å fremme denne endringen:

### Meldt inn av

Milla Weium, Backlog