### PR TITLE
Vedtektsforslag 02: Backlogs medlemssammensetning

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -146,7 +146,7 @@ Komiteens hovedoppgave er å sørge for økt trivsel blant informatikere i hverd
 
 ==== 4.2.8 Backlog
 
-Komiteens hovedoppgave vil være å bistå med kunnskap, erfaring og assistanse i linjeforeningens daglige drift. Komiteens medlemmer skal primært bestå av medlemmer som har hatt et aktivt verv i linjeforeningen i fire (4) semester. Leder av backlog godkjennes av Hovedstyret.
+Komiteens hovedoppgave vil være å bistå med kunnskap, erfaring og assistanse i linjeforeningens daglige drift. Leder av backlog godkjennes av Hovedstyret.
 
 ==== 4.2.9 Online idrettslag
 


### PR DESCRIPTION
# Bakgrunn for saken

I vedtektene til backlog (4.2.8) står det at backlog skal primært (flertallet) bestå av medlemmer som har hatt et aktivt verv i linjeforeningen i fire semester. Dette er noe som henger igjen fra seniorkom sin struktur da komiteen hovedsaklig bestod av medlemmer som var permittert fra sin opprinnelige komite for å være med som medlem i seniorkom. Dette er noe vi ønsker å endre slik at det ikke er lagt noen føringer eller krav på hvor mye erfaring man må ha for å være med i backlog

### Meldt inn av

Milla Weium, Backlog