### PR TITLE
Vedtektsforslag 01: Endre på Hovedstyrets sammensetning (2023H)

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -60,35 +60,23 @@ På spesielt grunnlag kan Hovedstyret, ved 2/3 kvalifisert flertall, tillate and
 
 === 4.1 Hovedstyret
 
-Hovedstyret er linjeforeningens øverste organ mellom generalforsamlingene. Hovedstyrets medlemmer velges på generalforsamlingen og skal drive linjeforeningen mellom generalforsamlingene. For at Hovedstyret skal være beslutningsdyktig må minst halvparten (1/2) av representantene være tilstede.
+Hovedstyret er linjeforeningens øverste organ mellom generalforsamlingene. Hovedstyrets medlemmer velges på generalforsamlingen og skal drive linjeforeningen mellom generalforsamlingene. For at Hovedstyret skal være beslutningsdyktig må minst halvparten (1/2) av styremedlemmene være tilstede.
 
-Ingen kan inneha to verv i Hovedstyret. Leder har dobbeltstemme ved stemmelikhet. Hovedstyrets møter er lukket, men gjester kan inviteres dersom Hovedstyret ønsker dette. Hovedstyret skrives med stor ’H’ på samme måte som egennavn.
+Ingen kan inneha to verv i Hovedstyret. Leder har dobbeltstemme ved stemmelikhet. Hovedstyrets møter er lukket, men gjester kan inviteres dersom Hovedstyret ønsker dette. Ved saker som angår en eller flere komiteer har kommunikasjonsansvarlig(e) fra komiteen(e) rett til å enten møte selv, eller sende noen andre fra komiteen sin.
 
 Leder av linjeforeningen Online har HMS-ansvar i organisasjonen.
 
 ==== 4.1.1 Hovedstyrets sammensetning
 
-Hovedstyret består av:
-
-* Leder
-* Nestleder
-* Økonomiansvarlig
-* Styrerepresentant for Arrangementskomiteen
-* Styrerepresentant for Bedriftskomiteen
-* Styrerepresentant for Drifts- og utviklingskomiteen
-* Styrerepresentant for Fag- og kurskomiteen
-* Styrerepresentant for Profil- og aviskomiteen
-* Styrerepresentant for Trivselskomiteen
+Hovedstyret består av Leder, Nestleder, Økonomiansvarlig, og tre styremedlemmer
 
 ==== 4.1.2 Fravær av hovedstyremedlem
 
-Dersom en komité sin styrerepresentant blir fraværende er det komitéleder som tar over styrerepresentantens plikter, oppgaver og rettigheter. Dersom komitéleder ikke er tilgjengelig plikter Hovedstyret å fylle stillingen.
-
-Dersom leder, nestleder og/eller økonomiansvarlig av linjeforeningen blir fraværende i den grad at det går utover vervets arbeidsoppgaver skal det innkalles til ekstraordinær generalforsamling for å fylle vervet.
+Dersom noen av Hovedstyrets medlemmer blir fraværende i den grad at det går utover vervets arbeidsoppgaver skal det innkalles til ekstraordinær generalforsamling for å fylle vervet.
 
 ==== 4.1.3 Krav til kandidater
 
-Kandidater til Hovedstyret må ha innehatt et verv i en av komiteene i linjeforeningen i minst ett (1) semester. Om en kandidat til styrerepresentant ikke har innehatt et verv i en komité, må kandidaten foreslås av valgkomiteen. Dersom kandidaten er med i Debug, må de permitteres fra dette vervet.
+Kandidater til Hovedstyret må ha innehatt et verv i en av komiteene i linjeforeningen i minst ett (1) semester. Om en kandidat ikke har innehatt et verv i en komité, må kandidaten foreslås av valgkomiteen. Dersom kandidaten er med i Debug, må de permitteres fra dette vervet. Dersom en kandidat blir tatt opp til Hovedstyret, må de permitteres fra alle eventuelle verv i Onlines komiteer og nodekomiteer, og kan ikke inneha disse vervene så lenge de sitter i styret.
 
 ==== 4.1.4 Valg av Hovedstyre
 
@@ -102,13 +90,12 @@ Ved Ordinær generalforsamlingen utlyses:
 
 Ved Sekundær generalforsamlingen utlyses:
 
-* Øvrige styrerepresentanter
+* Øvrige styremedlemmer
 
 Sittende styremedlemmer kan stille som kandidat selv om de ikke fratrer vervet sitt samme generalforsamling de stiller. Sittende styremedlemmer som ønsker å stille til valg i ny rolle må varsle om dette senest ved innkallingen til generalforsamlingen, som sendes ut fire (4) uker før generalforsamlingen. Dersom kandidaten vinner skal det avholdes ekstraordinært valg for den avtroppende styreposisjonen.
 
 === 4.2 Komiteer
-
-Alle komiteer består av minimum en leder, en økonomiansvarlig og en tillitsvalgt. Komiteer med stemmerett i Hovedstyret skal i tillegg bestå av et styremedlem.
+Alle komiteer består av minimum en leder, en økonomiansvarlig, en tillitsvalgt og en kommunikasjonsansvarlig. Rollen som kommunikasjonsansvarlig kan kombineres med hvilken som helst annen rolle i komiteen.
 
 Komiteens lederkandidat, med unntak av nodekomiteer, velges internt i komiteen før ordinær generalforsamling avholdes, og godkjennes av generalforsamlingen ved alminnelig flertall. Dersom komitélederkandidaten har blitt stemt inn i Hovedstyret skal det avholdes valg av komitéleder etter §3. Hvis kandidaten ikke har blitt stemt inn i Hovedstyret, og generalforsamlingen ikke godkjenner kandidaten til ledervervet, skal det avholdes valg av komitéleder etter §3.
 


### PR DESCRIPTION
# Bakgrunn for saken
Ble stemt gjennom saksforslag i vår om å nedsette en arbeidsgruppe for undersøkelse av vår organisasjonsstruktur og alternative strukturer.

Online har vokst mye de siste årene, og vi har i løpet av kort tid fått tre nye komiteer. Til tross for dette så har ikke organisasjonsstrukturen til Online endret seg noe, og man kan se litt problemer med dette når det kommer til kommunikasjonsflyt i linjeforeningen.

Vi har per i dag 11 komiteer og 4 nodekomiteer. Av disse så er det kun 7 av komiteene som er direkte representert i Hovedstyret gjennom en styrerepresentant eller økonomiansvarlig. Komiteene uten styrerepresentant har nestleder av Online som kontaktpunkt, kontra de andre som har en spesifikk representant. Dette kan gjøre at terskelen for å ta kontakt med HS, og få informasjon fra HS blir vanskeligere.

### Meldt inn av

Njål Ingersønn sørland
