### PR TITLE
Vedtektsforslag 03: Endre ordlyden i vedtekten om medlemmer av Debug som stiller til hovedstyret (2023H)

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -76,7 +76,7 @@ Dersom noen av Hovedstyrets medlemmer blir fraværende i den grad at det går ut
 
 ==== 4.1.3 Krav til kandidater
 
-Kandidater til Hovedstyret må ha innehatt et verv i en av komiteene i linjeforeningen i minst ett (1) semester. Om en kandidat ikke har innehatt et verv i en komité, må kandidaten foreslås av valgkomiteen. Dersom kandidaten er med i Debug, må de permitteres fra dette vervet. Dersom en kandidat blir tatt opp til Hovedstyret, må de permitteres fra alle eventuelle verv i Onlines komiteer og nodekomiteer, og kan ikke inneha disse vervene så lenge de sitter i styret.
+Kandidater til Hovedstyret må ha innehatt et verv i en av komiteene i linjeforeningen i minst ett (1) semester. Om en kandidat ikke har innehatt et verv i en komité, må kandidaten foreslås av valgkomiteen. Dersom en kandidat blir tatt opp til Hovedstyret, må de permitteres fra alle eventuelle verv i Onlines komiteer, nodekomiteer og Debug, og kan ikke inneha disse vervene så lenge de sitter i styret.
 
 ==== 4.1.4 Valg av Hovedstyre
 


### PR DESCRIPTION
# Bakgrunn for saken

Vedtektsforslaget om at Debug medlemmer ikke kan sitte i hovedstyret gikk gjennom i vår, men vi fikk tilbakemeldinger om at ordlyden ikke var tydelig og presis nok. Hovedstyret har nå skrevet et forslag til en tydeligere vedtekt.

### Meldt inn av

Carolina Gunnesdal og Frida Eriksen Næss
