### PR TITLE
Vedtektsforslag 04: Bedkom ansvarlige for ITEX

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -163,10 +163,6 @@ Komiteens hovedoppgave er å organisere fadderperiode for nye studenter. Komitee
 
 Komiteens hovedoppgave er å organisere hovedekskursjonen. Komiteens navn forkortes ekskom. Ekskursjonskomiteen opererer frittstående fra linjeforeningen, som en egen organisasjon.
 
-==== 4.3.4 Informatikernes IT-ekskursjon
-
-Komiteens hovedoppgave er å arrangere ekskursjon til Oslo for masterstudenter hver høst. Komiteens navn forkortes Itex.
-
 === 4.4 Andre grupper tilknyttet Online
 
 ==== 4.4.1 Redaksjonen


### PR DESCRIPTION
# Bakgrunn for saken

ITEX er et viktig arrangement for informatikkstudenter i deres jobbsøkeprosess. For øyeblikket organiseres ITEX av nodekomiteen ITEX. 

Bedkom har det siste halvåret spesielt opplevd en nedgang i bedrifters interesse for å drive studentrekruttering. Dette har gjort det vanskeligere for oss å kunne sikre inntektene som Online budsjetterer for. Per nå sikrer bedkom inntekter til Online gjennom bedriftspresentasjoner og andre sponsormidler, herunder fadderuker, offline-annonser og kaffesponsor.

ITEX er et attraktivt produkt som ønskes av mange bedrifter. For å sikre bedrifter til våre arrangementer har vi i tilfeller blitt nødt til å garantere bedriften plass på ITEX. Slik ITEX er organisert nå, sitter ikke bookingrunden i en posisjon til å kunne innfri disse ønskene fra bedrifter, og vi opplever dette som svært uheldig. Bookingrunden er prosessen hvor bedkom og fagkom booker bedrifter til påfølgende semester. Slik det er nå, er ikke ITEX inkludert i denne prosessen, og deres booking av bedrifter starter etter at bookingrunden er avsluttet. Samtidig mener vi at ITEX sine kontrakter, innhold og priser, bør være i tråd med våre eksisterende avtaler. Dette er per nå ikke noe vi har kontroll på. 

Forslaget vil føre til at ITEX oppløses som nodekomite, men vi mener dette kompenseres for ved å ta opp flere ordinære komitemedlemmer i Bedkom, som vil ha medlemskap i flere år. Dette vil medføre praktiske endringer i Bedkom, noe vi mener vi har kapasitet til å håndtere.

For å sikre planlagte inntekter og aktivitet i Online mener vi ITEX burde innlemmes i Bedkoms allerede eksisterende bedriftsansvar.
 
### Meldt inn av

Magnus Ouren og Ingrid Helene Kvitnes
