### PR TITLE
Vedtektsforslag 03: Fjerne at Hovedstyret godkjenner interessegrupper

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -32,7 +32,7 @@ Studenter ved følgende studier ved NTNU har rett til å bli medlem av linjefore
 
 === 3.2 Medlemmers rettigheter
 
-Alle medlemmer har rett til å delta på, og fremme saker og vedtektsforslag, til generalforsamlingen. Alle medlemmer av linjeforeningen har rett til å søke Hovedstyret om å starte opp interessegrupper. Alle medlemmer har rett til å delta på de arrangementer som arrangeres for medlemmene, gitt at medlemmet er i arrangementets målgruppe. Medlemmer av linjeforeningen kan kreve innsyn i linjeforeningens regnskap og kan få innsyn i ikke-konfidensielle vedtak.
+Alle medlemmer har rett til å delta på, og fremme saker og vedtektsforslag, til generalforsamlingen. Alle medlemmer av linjeforeningen har rett til å søke Backlog om å starte opp interessegrupper. Alle medlemmer har rett til å delta på de arrangementer som arrangeres for medlemmene, gitt at medlemmet er i arrangementets målgruppe. Medlemmer av linjeforeningen kan kreve innsyn i linjeforeningens regnskap og kan få innsyn i ikke-konfidensielle vedtak.
 
 ==== 3.2.1 Livstidsmedlemmer
 


### PR DESCRIPTION
Vedtektsforslag 03: Fjerne at Hovedstyret godkjenner interessegrupper

# Bakgrunn for saken

Bakgrunn: I vedtektene står det nå at alle medlemmer har rett til å søke Hovedstyret om å starte opp interessegrupper. Denne prosessen er flyttet til Backlog og det er de som har hovedansvaret for interessegrupper.

### Meldt inn av

Ida Matre
