### PR TITLE
Vedtektsforslag 06: Styremedlemmer kan returnere til permittert verv …

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -203,11 +203,7 @@ Et komitémedlem kan søke om permisjon fra et komitéverv i Online. Man må ha 
 
 ==== 4.6.2 Verv i Hovedstyret
 
-Dersom et komitémedlem blir valgt til et av følgende hovedstyreverv vil medlemmet automatisk få permisjon fra sin komité, og kan fritt returnere til denne ved endt engasjement i Hovedstyret:
-
-* Leder
-* Nestleder
-* Økonomiansvarlig
+Dersom et komitémedlem blir valgt til et hovedstyreverv jf. §4.1.1 vil medlemmet automatisk få permisjon fra sine andre verv jf. §4.1.3, og kan fritt returnere til disse ved endt engasjement i Hovedstyret.
 
 ==== 4.6.3 Advarsel og oppsigelse
 


### PR DESCRIPTION
…etter endt engasjement

# Bakgrunn for saken

Bakgrunn: På høstens generalforsamling ble det vedtatt ny organisasjonsstruktur hvor styrerepresentanter ble byttet ut med styremedlemmer. Tidligere forble styrerepresentanter også medlemmer i komiteen sin, da var det ikke behov for å spesifisere de i denne vedtekten (§4.6.2). Styremedlemmer blir i dag permittert fra tidligere verv, men kan ikke fritt returnere til disse ved endt engasjement slik som resterende hovedstyreverv.

### Meldt inn av

Frederik Farstad