### PR TITLE
Vedketksforslag 01

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -76,7 +76,7 @@ Dersom noen av Hovedstyrets medlemmer blir fraværende i den grad at det går ut
 
 ==== 4.1.3 Krav til kandidater
 
-Kandidater til Hovedstyret må ha innehatt et verv i en av komiteene i linjeforeningen i minst ett (1) semester. Om en kandidat ikke har innehatt et verv i en komité, må kandidaten foreslås av valgkomiteen. Dersom en kandidat blir tatt opp til Hovedstyret, må de permitteres fra alle eventuelle verv i Onlines komiteer, nodekomiteer og Debug, og kan ikke inneha disse vervene så lenge de sitter i styret.
+Kandidater til Hovedstyret må ha innehatt et verv i en av komiteene i linjeforeningen i minst ett (1) semester. Om en kandidat ikke har innehatt et verv i en komité, må kandidaten foreslås av valgkomiteen. Dersom en kandidat blir tatt opp til Hovedstyret, må de permitteres fra alle eventuelle verv i Onlines komiteer, nodekomiteer og Debug, og kan ikke inneha disse vervene så lenge de sitter i styret. Det eneste unntaket er Økonomiansvarlig i Online som plikter å sitte i bankom.
 
 ==== 4.1.4 Valg av Hovedstyre
 


### PR DESCRIPTION
Endret 4.1.3

# Bakgrunn for saken

Som økonomiansvarlig må man sitte i bankom. Ut i fra denne vedtekten er det teknisk sett ikke lov. Vi ønsker å endre denne vedtekten for å tydeliggjøre at Økonomiansvarlig skal være medlem i bankom.


### Meldt inn av

Johanna Wilmers
