### PR TITLE
Vedtektsforslag 07

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -80,19 +80,14 @@ Kandidater til Hovedstyret må ha innehatt et verv i en av komiteene i linjefore
 
 ==== 4.1.4 Valg av Hovedstyre
 
-Verv i Hovedstyret varer normalt i to semestere og utlyses ved generalforsamlinger. Året etter et styremedlem har gått av, plikter vedkommende å behandle klager sendt inn i henhold til §4.7.3. Dersom vedkommende ikke lenger er student i Trondheim, frafaller denne plikten.
+Verv i Hovedstyret varer normalt i to semestere og utlyses ved Ordinær generalforsamling. Året etter et styremedlem har gått av, plikter vedkommende å behandle klager sendt inn i henhold til §4.7.3. Dersom vedkommende ikke lenger er student i Trondheim, frafaller denne plikten.
 
 Ved Ordinær generalforsamlingen utlyses:
 
 * Leder
 * Nestleder
 * Økonomiansvarlig
-
-Ved Sekundær generalforsamlingen utlyses:
-
 * Øvrige styremedlemmer
-
-Sittende styremedlemmer kan stille som kandidat selv om de ikke fratrer vervet sitt samme generalforsamling de stiller. Sittende styremedlemmer som ønsker å stille til valg i ny rolle må varsle om dette senest ved innkallingen til generalforsamlingen, som sendes ut fire (4) uker før generalforsamlingen. Dersom kandidaten vinner skal det avholdes ekstraordinært valg for den avtroppende styreposisjonen.
 
 === 4.2 Komiteer
 Alle komiteer består av minimum en leder, en økonomiansvarlig, en tillitsvalgt og en kommunikasjonsansvarlig. Rollen som kommunikasjonsansvarlig kan kombineres med hvilken som helst annen rolle i komiteen.


### PR DESCRIPTION
Endret 4.1.4

# Bakgrunn for saken

På generalforsamlingen våren 2022, ble det besluttet å splitte valg av HS-medlemmene. Dette innebærer at leder, nestleder, og økonomiansvarlig nå vil bli valgt om våren, mens valget av de resterende styremedlemmene er flyttet til høstperioden.

HS oppfordret Organisasjonsstrukturgruppa til å evaluere effektiviteten av den nåværende ordningen. Som et resultat, ble det gjennomført en spørreundersøkelse med deltakelse fra både tidligere og nåværende HS-medlemmer, i tillegg til samtaler med det sittende HS. Basert på funnene fra disse undersøkelsene, ble det klart at den eksisterende strukturen ikke fungerer optimalt, noe som indikerer et behov for endring


### Meldt inn av

Johanna Wilmers
