### PR TITLE
Fjerne paragraf om fullverdig medlemsskap til ikke-informatikere

### DIFF
--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -54,10 +54,6 @@ Hovedstyret kan, ved skjellig grunn, utestenge medlemmer fra linjeforeningen, mi
 
 Studenter ved andre fakulteter og linjer som har informatikk som et av sine hovedstudier kan søke om sosialt medlemskap. Søknaden sendes inn til Hovedstyret med dokumentasjon på at vedkommende tar alle obligatoriske emner ved informatikk. 
 
-=== 3.5 Adgang for andre til å bli fullverdig medlem
-
-På spesielt grunnlag kan Hovedstyret, ved 2/3 kvalifisert flertall, tillate andre studenter å bli fullverdig medlem.
-
 == 4 Struktur, ledelse og organisasjon
 
 === 4.1 Hovedstyret

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -52,7 +52,11 @@ Hovedstyret kan, ved skjellig grunn, utestenge medlemmer fra linjeforeningen, mi
 
 === 3.4 Adgang for andre til å bli sosialt medlem
 
-På spesielt grunnlag kan Hovedstyret, ved kvalifisert flertall, tillate andre å bli sosiale medlem. Dette gjelder primært studenter ved andre fakulteter og linjer som har informatikk som et av sine hovedstudier.
+Studenter ved andre fakulteter og linjer som har informatikk som et av sine hovedstudier kan søke om sosialt medlemskap. Søknaden sendes inn til Hovedstyret med dokumentasjon på at vedkommende tar alle obligatoriske emner ved informatikk. 
+
+=== 3.5 Adgang for andre til å bli fullverdig medlem
+
+På spesielt grunnlag kan Hovedstyret, ved 2/3 kvalifisert flertall, tillate andre studenter å bli fullverdig medlem.
 
 == 4 Struktur, ledelse og organisasjon
 

--- a/vedtekter.adoc
+++ b/vedtekter.adoc
@@ -52,11 +52,7 @@ Hovedstyret kan, ved skjellig grunn, utestenge medlemmer fra linjeforeningen, mi
 
 === 3.4 Adgang for andre til å bli sosialt medlem
 
-Studenter ved andre fakulteter og linjer som har informatikk som et av sine hovedstudier kan søke om sosialt medlemskap. Søknaden sendes inn til Hovedstyret med dokumentasjon på at vedkommende tar alle obligatoriske emner ved informatikk. 
-
-=== 3.5 Adgang for andre til å bli fullverdig medlem
-
-På spesielt grunnlag kan Hovedstyret, ved 2/3 kvalifisert flertall, tillate andre studenter å bli fullverdig medlem.
+På spesielt grunnlag kan Hovedstyret, ved kvalifisert flertall, tillate andre å bli sosiale medlem. Dette gjelder primært studenter ved andre fakulteter og linjer som har informatikk som et av sine hovedstudier.
 
 == 4 Struktur, ledelse og organisasjon
 


### PR DESCRIPTION
# Bakgrunn for saken

Slik vedtektene er i dag kan man søke om å være “ikke-sosialt” medlem selv om man ikke går informatikk. Dette burde ikke være nødvendig da sosiale medlemmer i utgangspunktet har de samme rettighetene som vanlige medlemmer, og det kompliserer reglene for påmelding.
Paragrafen ble opprinnelig lagt tidligere inn fordi man skulle gjøre en ikke-informatiker til ridder, men det er ikke nevnt noen steder at man ikke kan være sosialt medlem og ridder.

### Meldt inn av

Jo Gramnæs Tjernshaugen